### PR TITLE
Fix module by adding sequence to reservation reference

### DIFF
--- a/reserva_salas/__manifest__.py
+++ b/reserva_salas/__manifest__.py
@@ -10,6 +10,7 @@
     "data": [
         "security/security.xml",
         "security/ir.model.access.csv",
+        "data/ir_sequence.xml",
         "views/acciones.xml",
         "views/sala_views.xml",
         "views/reserva_views.xml",

--- a/reserva_salas/data/ir_sequence.xml
+++ b/reserva_salas/data/ir_sequence.xml
@@ -1,0 +1,9 @@
+<odoo>
+    <record id="seq_reserva_reunion" model="ir.sequence">
+        <field name="name">Reserva de Reunión</field>
+        <field name="code">reserva.reunion</field>
+        <field name="prefix">RES</field>
+        <field name="padding">4</field>
+        <field name="company_id" eval="False"/>
+    </record>
+</odoo>

--- a/reserva_salas/models/reserva.py
+++ b/reserva_salas/models/reserva.py
@@ -24,6 +24,12 @@ class ReservaReunion(models.Model):
         readonly=True,
     )
 
+    @api.model
+    def create(self, vals):
+        if vals.get('referencia', 'Nuevo') == 'Nuevo':
+            vals['referencia'] = self.env['ir.sequence'].next_by_code('reserva.reunion') or 'Nuevo'
+        return super().create(vals)
+
     @api.constrains('sala_id', 'fecha_inicio', 'fecha_fin')
     def _check_solapamiento(self):
         for reserva in self:


### PR DESCRIPTION
## Summary
- add `ir.sequence` to generate references for reservations
- use sequence in `ReservaReunion.create`
- load the sequence in manifest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68801dc99908833182292b994ce7622e